### PR TITLE
Allow frames from local server

### DIFF
--- a/Launcher/src-tauri/tauri.conf.json
+++ b/Launcher/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
       { "title": "WeylandTavern", "width": 1200, "height": 800, "resizable": true }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' http://127.0.0.1:*; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'",
+      "csp": "default-src 'self'; connect-src 'self' http://127.0.0.1:*; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-src 'self' http://127.0.0.1:*;",
       "capabilities": [
         {
           "identifier": "main",


### PR DESCRIPTION
## Summary
- extend the Tauri content security policy to allow framing content from the local SillyTavern server

## Testing
- npm run tauri build *(fails: The bundle identifier "https://ko-fi.com/luckypaw" set in `tauri.conf.json identifier`. The bundle identifier string must contain only alphanumeric characters (A-Z, a-z, and 0-9), hyphens (-), and periods (.).)*
- npm run build *(fails: Rollup failed to resolve import "@tauri-apps/api/process" from "src/App.tsx".)*


------
https://chatgpt.com/codex/tasks/task_e_68c867c26660832ea59ce88447a3900d