### PR TITLE
Use window close on Ctrl+Q

### DIFF
--- a/Launcher/src/App.tsx
+++ b/Launcher/src/App.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { listen } from '@tauri-apps/api/event';
-import { exit } from '@tauri-apps/api/process';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+
+const appWindow = getCurrentWindow();
 
 function App() {
   const [ready, setReady] = useState(false);
@@ -24,7 +26,8 @@ function App() {
         e.preventDefault();
         setShowLogs((v) => !v);
       } else if (e.ctrlKey && e.key.toLowerCase() === 'q') {
-        exit(0);
+        e.preventDefault();
+        void appWindow.close();
       }
     };
     window.addEventListener('keydown', handler);


### PR DESCRIPTION
## Summary
- replace the Ctrl+Q handler to close the current Tauri window instead of forcing a process exit
- rely on the window CloseRequested handler to run the existing shutdown sequence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c86bbeaa38832ead388c5253d8adf5