### PR TITLE
Implement interactive update flow and integrate tauri launcher

### DIFF
--- a/Launcher/package.json
+++ b/Launcher/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "dev": "tauri dev",
+    "build": "tauri build",
+    "ui:dev": "vite",
+    "ui:build": "vite build",
     "tauri": "tauri",
     "test": "echo \"no tests\""
   },

--- a/Launcher/src-tauri/Cargo.lock
+++ b/Launcher/src-tauri/Cargo.lock
@@ -235,11 +235,11 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.12"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5"
+checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -272,14 +272,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml 0.9.5",
+ "toml 0.9.6",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -684,7 +684,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 0.9.5",
+ "toml 0.9.6",
  "vswhom",
  "winreg 0.55.0",
 ]
@@ -712,11 +712,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+checksum = "259d404d09818dec19332e31d94558aeb442fea04c817006456c24b5460bbd4b"
 dependencies = [
  "serde",
+ "serde_core",
  "typeid",
 ]
 
@@ -1028,7 +1029,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1197,7 +1198,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1375,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1399,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1409,7 +1410,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.0",
 ]
 
 [[package]]
@@ -1557,13 +1558,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1704,7 +1706,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
  "cssparser",
  "html5ever",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "selectors",
 ]
 
@@ -1756,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags 2.9.4",
  "libc",
@@ -2431,12 +2433,12 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.4"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "quick-xml",
  "serde",
  "time",
@@ -2968,38 +2970,50 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.224"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-untagged"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34836a629bcbc6f1afdf0907a744870039b1e14c0561cb26094fa683b158eff3"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
 dependencies = [
  "erased-serde",
  "serde",
+ "serde_core",
  "typeid",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.224"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.224"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3019,14 +3033,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3051,11 +3066,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3080,7 +3095,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -3515,7 +3530,7 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.5",
+ "toml 0.9.6",
  "walkdir",
 ]
 
@@ -3643,7 +3658,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.16",
- "toml 0.9.5",
+ "toml 0.9.6",
  "url",
  "urlpattern",
  "uuid",
@@ -3657,7 +3672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd21509dd1fa9bd355dc29894a6ff10635880732396aa38c0066c1e6c1ab8074"
 dependencies = [
  "embed-resource",
- "toml 0.9.5",
+ "toml 0.9.6",
 ]
 
 [[package]]
@@ -3818,14 +3833,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
 dependencies = [
- "indexmap 2.11.1",
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
+ "indexmap 2.11.3",
+ "serde_core",
+ "serde_spanned 1.0.1",
+ "toml_datetime 0.7.1",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.13",
@@ -3842,11 +3857,11 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3855,7 +3870,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -3866,7 +3881,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -4164,18 +4179,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.5+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
  "wasip2",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
@@ -4368,6 +4383,7 @@ dependencies = [
  "chrono",
  "dotenvy",
  "reqwest 0.11.27",
+ "serde",
  "tauri",
  "tokio",
  "windows 0.52.0",
@@ -4469,8 +4485,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
 ]
 
 [[package]]
@@ -4538,12 +4567,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -4898,9 +4945,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"

--- a/Launcher/src-tauri/Cargo.toml
+++ b/Launcher/src-tauri/Cargo.toml
@@ -9,6 +9,8 @@ dotenvy = "0.15"
 tokio = { version = "1", features = ["process", "io-util", "macros", "signal", "time"] }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 chrono = { version = "0.4" }
+serde = { version = "1", features = ["derive"] }
+
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.52", features = ["Win32_Foundation", "Win32_System_Threading"] }

--- a/Launcher/src-tauri/src/main.rs
+++ b/Launcher/src-tauri/src/main.rs
@@ -1,20 +1,19 @@
 use std::{
     env, fs as stdfs,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
     time::Duration,
 };
 
 use chrono::Local;
 use dotenvy::from_filename;
+use serde::Serialize;
 use std::process::Stdio;
-use tauri::{
-    api::process::{Command, CommandChild, CommandEvent, Signal},
-    AppHandle, Manager,
-};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::{
     fs::{self as tokio_fs, OpenOptions},
-    io::AsyncWriteExt,
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::{Child as TokioChild, Command as TokioCommand},
     sync::Mutex as AsyncMutex,
     time::sleep,
 };
@@ -30,9 +29,35 @@ use windows::{
 };
 
 struct ServerState {
-    child: Mutex<Option<CommandChild>>,
+    child: Mutex<Option<TokioChild>>,
     #[cfg(windows)]
     job: Mutex<Option<windows::Win32::Foundation::HANDLE>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+enum UpdateStatus {
+    Success,
+    UpToDate,
+    NeedRetry,
+    Failed,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateResponse {
+    status: UpdateStatus,
+    message: String,
+    log_path: Option<String>,
+    diff: Option<String>,
+    stash_used: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CharacterResponse {
+    success: bool,
+    message: String,
 }
 
 #[tokio::main]
@@ -43,14 +68,14 @@ async fn main() {
             #[cfg(windows)]
             job: Mutex::new(None),
         })
-        .setup(|app| {
-            let app_handle = app.handle();
-            let state = app.state::<ServerState>().clone();
-            tauri::async_runtime::spawn(async move {
-                if let Err(e) = launch(&app_handle, &state).await {
-                    let _ = app_handle.emit_all("log", format!("startup error: {}", e));
-                }
-            });
+        .invoke_handler(tauri::generate_handler![
+            update_vendor,
+            finalize_stash,
+            run_character_sync,
+            start_server
+        ])
+        .setup(|_| {
+            load_env();
             Ok(())
         })
         .on_window_event(|window, event| {
@@ -68,56 +93,293 @@ async fn main() {
         .expect("error running tauri app");
 }
 
-async fn launch(app: &AppHandle, state: &tauri::State<'_, ServerState>) -> Result<(), String> {
+fn load_env() {
     let _ = from_filename("../.env").or_else(|_| from_filename(".env"));
+}
 
-    let silly_dir = PathBuf::from(
-        env::var("SILLYTAVERN_DIR").unwrap_or_else(|_| "./vendor/WeylandTavern/SillyTavern".into()),
-    );
-    if !silly_dir.exists() {
-        return Err(format!(
+fn silly_dir() -> Result<PathBuf, String> {
+    let path =
+        env::var("SILLYTAVERN_DIR").unwrap_or_else(|_| "./vendor/WeylandTavern/SillyTavern".into());
+    let path = PathBuf::from(path);
+    if path.exists() {
+        Ok(path)
+    } else {
+        Err(format!(
             "SILLYTAVERN_DIR does not exist at {}. Set SILLYTAVERN_DIR in .env",
-            silly_dir.display()
-        ));
+            path.display()
+        ))
+    }
+}
+
+fn vendor_dir() -> Result<PathBuf, String> {
+    let silly = silly_dir()?;
+    silly
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| "Unable to determine vendor directory".to_string())
+}
+
+async fn run_git(dir: &Path, args: &[&str]) -> Result<std::process::Output, String> {
+    TokioCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn write_update_log(log_path: &Path, pull: &str, diff: &str) -> Result<(), String> {
+    let mut file = tokio_fs::File::create(log_path)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut contents = String::from("git pull output:\n");
+    let trimmed_pull = pull.trim();
+    if trimmed_pull.is_empty() {
+        contents.push_str("(no output)");
+    } else {
+        contents.push_str(trimmed_pull);
+    }
+    contents.push_str("\n\nGit diff --compact-summary:\n");
+    if diff.trim().is_empty() {
+        contents.push_str("No differences.\n");
+    } else {
+        contents.push_str(diff.trim());
+        contents.push('\n');
+    }
+    file.write_all(contents.as_bytes())
+        .await
+        .map_err(|e| e.to_string())?;
+    file.flush().await.map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+async fn update_vendor(app: AppHandle, attempt_overwrite: bool) -> Result<UpdateResponse, String> {
+    load_env();
+    let silly = silly_dir()?;
+    let repo = vendor_dir()?;
+    let log_path = silly.join("WTUpdate.log");
+
+    let mut stash_used = false;
+
+    if attempt_overwrite {
+        log_line(&app, "Stashing local changes before retrying update...").await;
+        let output = run_git(&repo, &["stash"]).await?;
+        if !output.status.success() {
+            let details = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return Err(if details.trim().is_empty() {
+                "git stash failed".into()
+            } else {
+                format!("git stash failed: {}", details.trim())
+            });
+        }
+        stash_used = true;
+    } else {
+        log_line(&app, "Attempting to update WeylandTavern...").await;
+    }
+
+    let pull_output = run_git(&repo, &["pull"]).await?;
+    let pull_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&pull_output.stdout),
+        String::from_utf8_lossy(&pull_output.stderr)
+    );
+
+    if pull_output.status.success() {
+        let lower = pull_text.to_lowercase();
+        let (status, message) = if lower.contains("already up to date") {
+            (
+                UpdateStatus::UpToDate,
+                "WeylandTavern is up to date!".to_string(),
+            )
+        } else {
+            (
+                UpdateStatus::Success,
+                "WeylandTavern updated successfully.".to_string(),
+            )
+        };
+        log_line(&app, &message).await;
+        return Ok(UpdateResponse {
+            status,
+            message,
+            log_path: None,
+            diff: None,
+            stash_used,
+        });
+    }
+
+    log_line(&app, "There was an error updating WeylandTavern...").await;
+    log_line(&app, "Generating log file SillyTavern/WTUpdate.log...").await;
+
+    let diff_output = run_git(&repo, &["diff", "--compact-summary"]).await?;
+    let diff_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&diff_output.stdout),
+        String::from_utf8_lossy(&diff_output.stderr)
+    );
+
+    write_update_log(&log_path, &pull_text, &diff_text).await?;
+
+    let combined = {
+        let mut combined = pull_text.trim().to_string();
+        if !diff_text.trim().is_empty() {
+            if !combined.is_empty() {
+                combined.push_str("\n\n");
+            }
+            combined.push_str(diff_text.trim());
+        }
+        combined
+    };
+
+    let response = UpdateResponse {
+        status: if attempt_overwrite {
+            UpdateStatus::Failed
+        } else {
+            UpdateStatus::NeedRetry
+        },
+        message: if attempt_overwrite {
+            "Update failed even after stashing local changes.".to_string()
+        } else {
+            "There was an error updating WeylandTavern.".to_string()
+        },
+        log_path: Some(log_path.to_string_lossy().into_owned()),
+        diff: if combined.is_empty() {
+            None
+        } else {
+            Some(combined)
+        },
+        stash_used,
+    };
+
+    Ok(response)
+}
+
+#[tauri::command]
+async fn finalize_stash(app: AppHandle, revert: bool) -> Result<(), String> {
+    load_env();
+    let repo = vendor_dir()?;
+    let args: [&str; 2] = if revert {
+        ["stash", "pop"]
+    } else {
+        ["stash", "clear"]
+    };
+    if revert {
+        log_line(&app, "Reverting differing files post update...").await;
+    } else {
+        log_line(&app, "Discarding stashed changes...").await;
+    }
+    let output = run_git(&repo, &args).await?;
+    if !output.status.success() {
+        let details = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return Err(if details.trim().is_empty() {
+            "Failed to finalize stash".into()
+        } else {
+            details.trim().to_string()
+        });
+    }
+    Ok(())
+}
+
+#[tauri::command]
+async fn run_character_sync(app: AppHandle) -> Result<CharacterResponse, String> {
+    load_env();
+    let silly = silly_dir()?;
+    let url = env::var("CHARACTER_SYNC_URL")
+        .unwrap_or_else(|_| "https://mega.nz/folder/J5ARwZRI#2hnLHnLjXXNk3GGve7fjlw".into());
+
+    if url.trim().is_empty() {
+        return Ok(CharacterResponse {
+            success: false,
+            message: "Character sync URL is not configured.".into(),
+        });
+    }
+
+    log_line(&app, "Checking for character updates...").await;
+    let mut cmd = TokioCommand::new("node");
+    cmd.current_dir(&silly);
+    cmd.env("NODE_ENV", "production");
+    cmd.env("NO_BROWSER", "1");
+    cmd.env("BROWSER", "none");
+    cmd.args(["character-downloader.js", &url, "-u"]);
+
+    let output = cmd.output().await.map_err(|e| e.to_string())?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if output.status.success() {
+        if !stdout.trim().is_empty() {
+            log_line(&app, stdout.trim()).await;
+        }
+        Ok(CharacterResponse {
+            success: true,
+            message: "Character update completed.".into(),
+        })
+    } else {
+        let combined = format!("{}{}", stdout, stderr);
+        if !combined.trim().is_empty() {
+            log_line(&app, combined.trim()).await;
+        }
+        Ok(CharacterResponse {
+            success: false,
+            message: "Character update failed. Check logs for details.".into(),
+        })
+    }
+}
+
+#[tauri::command]
+async fn start_server(app: AppHandle, state: tauri::State<'_, ServerState>) -> Result<(), String> {
+    launch(&app, &state).await
+}
+
+async fn launch(app: &AppHandle, state: &tauri::State<'_, ServerState>) -> Result<(), String> {
+    load_env();
+    let silly_dir = silly_dir()?;
+
+    if state.child.lock().unwrap().is_some() {
+        log_line(app, "WeylandTavern is already running.").await;
+        return Ok(());
     }
 
     for bin in ["node", "npm"] {
-        if Command::new(bin).arg("--version").status().await.is_err() {
+        if TokioCommand::new(bin)
+            .arg("--version")
+            .status()
+            .await
+            .is_err()
+        {
             return Err(format!("{} not found", bin));
         }
     }
 
-    let run_npm = env::var("RUN_NPM_INSTALL").unwrap_or_else(|_| "auto".into());
-    let npm_mode = env::var("NPM_MODE").unwrap_or_else(|_| "ci".into());
+    let run_npm = env::var("RUN_NPM_INSTALL").unwrap_or_else(|_| "always".into());
+    let npm_mode = env::var("NPM_MODE").unwrap_or_else(|_| "install".into());
     if should_npm_install(&run_npm, &silly_dir)? {
-        let mut cmd = Command::new("npm");
+        let mut cmd = TokioCommand::new("npm");
         cmd.current_dir(&silly_dir);
+        cmd.env("NODE_ENV", "production");
         if npm_mode == "ci" {
             cmd.arg("ci");
         } else {
-            cmd.args(["install", "--omit=dev"]);
+            cmd.args([
+                "install",
+                "--no-audit",
+                "--no-fund",
+                "--loglevel=error",
+                "--no-progress",
+                "--omit=dev",
+            ]);
         }
-        log_line(app, "running npm install").await;
+        log_line(app, "Installing Node modules...").await;
         if !cmd.status().await.map_err(|e| e.to_string())?.success() {
             return Err("npm install failed".into());
-        }
-    }
-
-    if env::var("RUN_CHARACTER_SYNC").unwrap_or_else(|_| "false".into()) == "true" {
-        let url = env::var("CHARACTER_SYNC_URL").unwrap_or_default();
-        if !url.is_empty() {
-            let mut cmd = Command::new("node");
-            cmd.current_dir(&silly_dir);
-            cmd.args(["character-downloader.js", &url, "-u"]);
-            cmd.env("NODE_ENV", "production");
-            cmd.env("NO_BROWSER", "1");
-            cmd.env("BROWSER", "none");
-
-            if cmd.status().await.is_err() {
-                log_line(app, "character sync failed").await;
-            }
-        } else {
-            log_line(app, "character sync url missing").await;
         }
     }
 
@@ -135,6 +397,8 @@ async fn launch(app: &AppHandle, state: &tauri::State<'_, ServerState>) -> Resul
         args.push("--no-open".into());
     }
 
+    log_line(app, "Starting WeylandTavern...").await;
+
     let logs_dir = PathBuf::from("logs");
     tokio_fs::create_dir_all(&logs_dir)
         .await
@@ -149,7 +413,7 @@ async fn launch(app: &AppHandle, state: &tauri::State<'_, ServerState>) -> Resul
             .map_err(|e| e.to_string())?,
     ));
 
-    let mut cmd = Command::new("node");
+    let mut cmd = TokioCommand::new("node");
     cmd.current_dir(&silly_dir);
     cmd.env("NODE_ENV", "production");
     cmd.env("NO_BROWSER", "1");
@@ -168,7 +432,10 @@ async fn launch(app: &AppHandle, state: &tauri::State<'_, ServerState>) -> Resul
     }
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
-    let (mut rx, mut child) = cmd.spawn().map_err(|e| e.to_string())?;
+    let mut child = cmd.spawn().map_err(|e| e.to_string())?;
+
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
 
     #[cfg(windows)]
     unsafe {
@@ -189,7 +456,7 @@ async fn launch(app: &AppHandle, state: &tauri::State<'_, ServerState>) -> Resul
             CloseHandle(job);
             return Err("SetInformationJobObject failed".into());
         }
-        let pid = child.pid().ok_or("pid unavailable")? as u32;
+        let pid = child.id().ok_or("pid unavailable")? as u32;
         let process = OpenProcess(PROCESS_ALL_ACCESS, false, pid);
         if process.is_invalid() {
             CloseHandle(job);
@@ -204,23 +471,38 @@ async fn launch(app: &AppHandle, state: &tauri::State<'_, ServerState>) -> Resul
         state.job.lock().unwrap().replace(job);
     }
 
-    state.child.lock().unwrap().replace(child);
-
-    let app_for_logs = app.clone();
-    let log_file = file.clone();
-    tauri::async_runtime::spawn(async move {
-        while let Some(ev) = rx.recv().await {
-            if let CommandEvent::Stdout(line) | CommandEvent::Stderr(line) = ev {
-                if let Ok(txt) = String::from_utf8(line) {
-                    let _ = append_log(&app_for_logs, &log_file, &txt).await;
-                }
+    if let Some(stdout) = stdout {
+        let app_for_logs = app.clone();
+        let log_file = file.clone();
+        tauri::async_runtime::spawn(async move {
+            let mut reader = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                let _ = append_log(&app_for_logs, &log_file, &line).await;
             }
-        }
-    });
+        });
+    }
+
+    if let Some(stderr) = stderr {
+        let app_for_logs = app.clone();
+        let log_file = file.clone();
+        tauri::async_runtime::spawn(async move {
+            let mut reader = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                let _ = append_log(&app_for_logs, &log_file, &line).await;
+            }
+        });
+    }
+
+    state.child.lock().unwrap().replace(child);
 
     let url = format!("http://{}:{}/", host, port);
     if wait_for_health(&url).await {
-        app.emit_all("server-ready", url).ok();
+        let friendly = format!(
+            "WeylandTavern is now active on {}:{} (By default)",
+            host, port
+        );
+        log_line(app, &friendly).await;
+        app.emit("server-ready", &url).ok();
     } else {
         log_line(app, "health check failed").await;
     }
@@ -236,12 +518,12 @@ async fn append_log(
     let mut f = file.lock().await;
     let _ = f.write_all(line.as_bytes()).await;
     let _ = f.write_all(b"\n").await;
-    let _ = app.emit_all("log", line.to_string());
+    let _ = app.emit("log", line.to_string());
     Ok(())
 }
 
 async fn log_line(app: &AppHandle, line: &str) {
-    let _ = app.emit_all("log", line.to_string());
+    let _ = app.emit("log", line.to_string());
 }
 
 fn should_npm_install(mode: &str, dir: &PathBuf) -> Result<bool, String> {
@@ -289,33 +571,13 @@ async fn wait_for_health(url: &str) -> bool {
 
 async fn shutdown(state: &tauri::State<'_, ServerState>) {
     if let Some(mut child) = state.child.lock().unwrap().take() {
+        let _ = child.kill().await;
+        let _ = child.wait().await;
         #[cfg(windows)]
-        let _ = child.signal(Signal::CtrlBreak);
-        #[cfg(not(windows))]
-        let _ = child.signal(Signal::Sigint);
-        if tokio::time::timeout(Duration::from_secs(5), child.wait())
-            .await
-            .is_err()
-        {
-            #[cfg(windows)]
-            {
-                if let Some(job) = state.job.lock().unwrap().take() {
-                    unsafe {
-                        TerminateJobObject(job, 1);
-                        CloseHandle(job);
-                    }
-                }
-            }
-            #[cfg(not(windows))]
-            {
-                let _ = child.kill();
-            }
-        } else {
-            #[cfg(windows)]
-            if let Some(job) = state.job.lock().unwrap().take() {
-                unsafe {
-                    CloseHandle(job);
-                }
+        if let Some(job) = state.job.lock().unwrap().take() {
+            unsafe {
+                TerminateJobObject(job, 1);
+                CloseHandle(job);
             }
         }
     } else {

--- a/Launcher/src-tauri/tauri.conf.json
+++ b/Launcher/src-tauri/tauri.conf.json
@@ -2,7 +2,12 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WeylandTavern",
   "identifier": "dev.launcher.WeylandTavern",
-  "build": { "beforeDevCommand": "", "beforeBuildCommand": "" },
+  "build": {
+    "beforeDevCommand": "npm run ui:dev",
+    "beforeBuildCommand": "npm run ui:build",
+    "devUrl": "http://localhost:5173",
+    "frontendDist": "../dist"
+  },
   "app": {
     "windows": [
       { "title": "WeylandTavern", "width": 1200, "height": 800, "resizable": true }

--- a/Launcher/src/App.tsx
+++ b/Launcher/src/App.tsx
@@ -1,14 +1,47 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
+import { invoke } from '@tauri-apps/api/core';
 
 const appWindow = getCurrentWindow();
+
+type UpdateStatus = 'success' | 'upToDate' | 'needRetry' | 'failed';
+
+interface UpdateResponse {
+  status: UpdateStatus;
+  message: string;
+  logPath?: string;
+  diff?: string;
+  stashUsed: boolean;
+}
+
+interface CharacterResponse {
+  success: boolean;
+  message: string;
+}
+
+type Step =
+  | 'updatePrompt'
+  | 'updating'
+  | 'updateRetry'
+  | 'updateFailed'
+  | 'stashPrompt'
+  | 'characterPrompt'
+  | 'characterRunning'
+  | 'launching';
 
 function App() {
   const [ready, setReady] = useState(false);
   const [url, setUrl] = useState('');
   const [logs, setLogs] = useState<string[]>([]);
   const [showLogs, setShowLogs] = useState(false);
+  const [step, setStep] = useState<Step>('updatePrompt');
+  const [updateResult, setUpdateResult] = useState<UpdateResponse | null>(null);
+  const [characterResult, setCharacterResult] = useState<CharacterResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [serverRequested, setServerRequested] = useState(false);
 
   useEffect(() => {
     const unlistenReady = listen<string>('server-ready', (e) => {
@@ -39,26 +72,296 @@ function App() {
     };
   }, []);
 
-  if (!ready) {
+  useEffect(() => {
+    if (step === 'launching' && !serverRequested) {
+      setServerRequested(true);
+      setServerError(null);
+      void invoke('start_server')
+        .catch((err) => {
+          setServerError(err instanceof Error ? err.message : String(err));
+          setServerRequested(false);
+        });
+    }
+  }, [step, serverRequested]);
+
+  const handleUpdate = async (attemptOverwrite: boolean) => {
+    setError(null);
+    setIsProcessing(true);
+    setStep('updating');
+    try {
+      const result = await invoke<UpdateResponse>('update_vendor', { attemptOverwrite });
+      setUpdateResult(result);
+      if (result.status === 'success' || result.status === 'upToDate') {
+        setStep(result.stashUsed ? 'stashPrompt' : 'characterPrompt');
+      } else if (result.status === 'needRetry') {
+        setStep('updateRetry');
+      } else {
+        setStep('updateFailed');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setStep('updateFailed');
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleSkipUpdate = () => {
+    setUpdateResult(null);
+    setStep('characterPrompt');
+  };
+
+  const handleRetryWithOverwrite = () => {
+    void handleUpdate(true);
+  };
+
+  const handleSkipAfterFailure = () => {
+    setUpdateResult((prev) =>
+      prev ? { ...prev, message: 'WeylandTavern failed to update.' } : prev
+    );
+    setStep('updateFailed');
+  };
+
+  const handleStartAnyway = () => {
+    setStep('characterPrompt');
+  };
+
+  const handleExit = () => {
+    void appWindow.close();
+  };
+
+  const handleFinalizeStash = async (revert: boolean) => {
+    setError(null);
+    setIsProcessing(true);
+    try {
+      await invoke('finalize_stash', { revert });
+      setStep('characterPrompt');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleCharacterSync = async () => {
+    setError(null);
+    setCharacterResult(null);
+    setIsProcessing(true);
+    setStep('characterRunning');
+    try {
+      const result = await invoke<CharacterResponse>('run_character_sync');
+      setCharacterResult(result);
+    } catch (err) {
+      setCharacterResult({
+        success: false,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsProcessing(false);
+      setStep('launching');
+    }
+  };
+
+  const handleSkipCharacter = () => {
+    setCharacterResult({ success: false, message: 'Character update skipped.' });
+    setStep('launching');
+  };
+
+  const retryServer = () => {
+    setServerError(null);
+    setServerRequested(false);
+  };
+
+  const buttonRowStyle = useMemo(
+    () => ({ display: 'flex', gap: '0.75rem', marginTop: '1rem', flexWrap: 'wrap' as const }),
+    []
+  );
+
+  const renderUpdateDetails = () => {
+    if (!updateResult || !updateResult.logPath) {
+      return null;
+    }
     return (
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}>
-        Loading...
+      <div style={{ marginTop: '0.75rem', maxWidth: '42rem' }}>
+        <p>
+          A log file was written to <code>{updateResult.logPath}</code>.
+        </p>
+        {updateResult.diff && (
+          <pre
+            style={{
+              backgroundColor: '#111',
+              color: '#0f0',
+              padding: '0.75rem',
+              borderRadius: '0.5rem',
+              maxHeight: '12rem',
+              overflow: 'auto',
+            }}
+          >
+            {updateResult.diff}
+          </pre>
+        )}
+      </div>
+    );
+  };
+
+  const renderStepContent = () => {
+    switch (step) {
+      case 'updatePrompt':
+        return (
+          <>
+            <p>Do you want to check for WeylandTavern updates?</p>
+            <div style={buttonRowStyle}>
+              <button onClick={() => handleUpdate(false)} disabled={isProcessing}>
+                Yes
+              </button>
+              <button onClick={handleSkipUpdate} disabled={isProcessing}>
+                No
+              </button>
+            </div>
+          </>
+        );
+      case 'updating':
+        return <p>Updating WeylandTavern...</p>;
+      case 'updateRetry':
+        return (
+          <>
+            <p>There was an error updating WeylandTavern.</p>
+            {renderUpdateDetails()}
+            <div style={buttonRowStyle}>
+              <button onClick={handleRetryWithOverwrite} disabled={isProcessing}>
+                Retry with overwrite
+              </button>
+              <button onClick={handleSkipAfterFailure} disabled={isProcessing}>
+                Skip update
+              </button>
+              <button onClick={handleExit} disabled={isProcessing}>
+                Exit
+              </button>
+            </div>
+          </>
+        );
+      case 'updateFailed':
+        return (
+          <>
+            <p>{updateResult?.message ?? 'WeylandTavern failed to update.'}</p>
+            <p>Start WeylandTavern anyway?</p>
+            {renderUpdateDetails()}
+            <div style={buttonRowStyle}>
+              <button onClick={handleStartAnyway} disabled={isProcessing}>
+                Start anyway
+              </button>
+              <button onClick={handleExit} disabled={isProcessing}>
+                Exit
+              </button>
+            </div>
+          </>
+        );
+      case 'stashPrompt':
+        return (
+          <>
+            <p>Revert differing files post update?</p>
+            <div style={buttonRowStyle}>
+              <button onClick={() => void handleFinalizeStash(true)} disabled={isProcessing}>
+                Yes
+              </button>
+              <button onClick={() => void handleFinalizeStash(false)} disabled={isProcessing}>
+                No
+              </button>
+            </div>
+          </>
+        );
+      case 'characterPrompt':
+        return (
+          <>
+            <p>Do you want to check for character updates?</p>
+            <div style={buttonRowStyle}>
+              <button onClick={() => void handleCharacterSync()} disabled={isProcessing}>
+                Yes
+              </button>
+              <button onClick={handleSkipCharacter} disabled={isProcessing}>
+                No
+              </button>
+            </div>
+          </>
+        );
+      case 'characterRunning':
+        return <p>Checking for character updates...</p>;
+      case 'launching':
+        return (
+          <>
+            <p>Starting WeylandTavern...</p>
+            {characterResult && (
+              <p style={{ marginTop: '0.5rem' }}>{characterResult.message}</p>
+            )}
+            {serverError && (
+              <div style={{ marginTop: '1rem' }}>
+                <p style={{ color: '#ff8a80' }}>Failed to start the server: {serverError}</p>
+                <button onClick={retryServer}>Retry start</button>
+              </div>
+            )}
+          </>
+        );
+      default:
+        return null;
+    }
+  };
+
+  if (ready) {
+    return (
+      <div style={{ width: '100vw', height: '100vh' }}>
+        <iframe src={url} style={{ border: 'none', width: '100%', height: '100%' }} />
+        {showLogs && (
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              backgroundColor: 'rgba(0,0,0,0.8)',
+              color: '#0f0',
+              overflow: 'auto',
+              padding: '1rem',
+            }}
+          >
+            <pre>{logs.join('\n')}</pre>
+          </div>
+        )}
       </div>
     );
   }
 
   return (
-    <div style={{ width: '100vw', height: '100vh' }}>
-      <iframe src={url} style={{ border: 'none', width: '100%', height: '100%' }} />
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        padding: '2rem',
+        gap: '1rem',
+        textAlign: 'center',
+      }}
+    >
+      <h1>WeylandTavern Launcher</h1>
+      {updateResult && (updateResult.status === 'success' || updateResult.status === 'upToDate') && (
+        <p>{updateResult.message}</p>
+      )}
+      {renderStepContent()}
+      {error && <p style={{ color: '#ff8a80' }}>{error}</p>}
+      <p style={{ fontSize: '0.9rem', opacity: 0.75 }}>
+        Use <kbd>Ctrl</kbd>+<kbd>L</kbd> to toggle logs, <kbd>Ctrl</kbd>+<kbd>R</kbd> to reload, and <kbd>Ctrl</kbd>+<kbd>Q</kbd> to quit.
+      </p>
       {showLogs && (
         <div
           style={{
-            position: 'absolute',
+            position: 'fixed',
             top: 0,
             left: 0,
             right: 0,
             bottom: 0,
-            backgroundColor: 'rgba(0,0,0,0.8)',
+            backgroundColor: 'rgba(0,0,0,0.85)',
             color: '#0f0',
             overflow: 'auto',
             padding: '1rem',
@@ -72,4 +375,3 @@ function App() {
 }
 
 export default App;
-


### PR DESCRIPTION
## Summary
- add backend commands that mirror the vendor update, stash, character sync, and server startup behaviour and stream logs into the launcher
- replace the React bootstrap with an interactive flow that prompts for vendor and character updates before launching the WebView and exposes retry/skip controls
- wire the dev workflow to `tauri dev`/`tauri build` and configure the Tauri build/dev pipeline for the Vite frontend

## Testing
- npm run ui:build

------
https://chatgpt.com/codex/tasks/task_e_68c88728f9f4832e9466ead44ea97383