### PR TITLE
Enable in-app vendor updates

### DIFF
--- a/Launcher/.env
+++ b/Launcher/.env
@@ -13,5 +13,5 @@ NPM_MODE=ci                   # ci|install
 RUN_CHARACTER_SYNC=true       # true|false
 
 # Update (Submodule)
-ALLOW_GIT_PULL_IN_APP=false   # always false for submodule
+ALLOW_GIT_PULL_IN_APP=true    # allow in-app vendor git pull
 UPDATE_SCRIPT=./tools/Update-WeylandTavern.ps1

--- a/Launcher/README.md
+++ b/Launcher/README.md
@@ -7,18 +7,25 @@ Tauri based launcher that bootstraps the bundled SillyTavern server and opens it
 - Rust toolchain (stable) for building the Tauri side.
 
 ## `.env`
-Create a `.env` file in the `Launcher/` directory with the following keys:
+The repo ships with `Launcher/.env` pre-populated for the bundled SillyTavern checkout. Adjust the values if your layout or
+preferences differ.
 
 ```
+WEYLANDTAVERN_DIR=./vendor/WeylandTavern
 SILLYTAVERN_DIR=./vendor/WeylandTavern/SillyTavern
 SERVER_HOST=127.0.0.1
 SERVER_PORT=8000
 SERVER_ARGS=--listen true --listen-host 0.0.0.0
 RUN_NPM_INSTALL=auto   # auto|always|never
 NPM_MODE=ci            # ci|install
-RUN_CHARACTER_SYNC=false
+RUN_CHARACTER_SYNC=true
+ALLOW_GIT_PULL_IN_APP=true
 UPDATE_SCRIPT=./tools/Update-WeylandTavern.ps1
 ```
+
+`ALLOW_GIT_PULL_IN_APP` controls whether the launcher is allowed to run `git pull` against the vendor checkout during the
+Update step. Leave this enabled to trigger updates from inside the app, or set it to `false` if you prefer to run the
+PowerShell script manually.
 
 The launcher also sets the following environment variables internally to prevent an external browser from opening:
 ```
@@ -26,7 +33,8 @@ NO_BROWSER=1
 BROWSER=none
 ```
 
-`SILLYTAVERN_DIR` defaults to `./vendor/WeylandTavern/SillyTavern` and the launcher will fail to start if the path does not exist.
+`SILLYTAVERN_DIR` defaults to `./vendor/WeylandTavern/SillyTavern` and the launcher will fail to start if the path does not
+exist.
 
 ## Usage
 
@@ -51,5 +59,5 @@ A strict content security policy allows resources from `self` and connections to
 ## Troubleshooting
 - Ensure `SILLYTAVERN_DIR` points to a valid SillyTavern checkout.
 - `RUN_NPM_INSTALL=never` skips the npm step; use `auto` or `always` if dependencies are missing.
-- Set `RUN_CHARACTER_SYNC=true` to invoke `character-downloader.js` (non‑fatal on failure).
+- Leave `RUN_CHARACTER_SYNC=true` (default) to invoke `character-downloader.js` (non‑fatal on failure); set it to `false` to skip the sync.
 


### PR DESCRIPTION
## Summary
- enable in-app git pulls by default in the launcher `.env` so the UI can perform vendor updates
- expand the README configuration section with the default values and document the new `ALLOW_GIT_PULL_IN_APP` toggle

## Testing
- not run (config/documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68c95ccdb908832e9fcfe35fca1d8a6b