### PR TITLE
Improve server port and shutdown handling

### DIFF
--- a/Launcher/src-tauri/Cargo.lock
+++ b/Launcher/src-tauri/Cargo.lock
@@ -4382,6 +4382,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dotenvy",
+ "libc",
  "reqwest 0.11.27",
  "serde",
  "tauri",

--- a/Launcher/src-tauri/Cargo.toml
+++ b/Launcher/src-tauri/Cargo.toml
@@ -20,5 +20,8 @@ windows = { version = "0.61.3", features = [
     "Win32_System_Threading",
 ] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }


### PR DESCRIPTION
## Summary
- add a reusable helper so every spawned Node process (npm install, character sync, locate_npm fallback, server) runs with the production browser-less environment and honour `NPM_MODE`
- determine the server port from SillyTavern's `.env`, fall back to the launcher port setting or the first open port in a fallback list, and always include `--no-open`
- shut down the Node process tree cleanly across platforms (Windows JobObject or Unix SIGINT/SIGKILL) and add the `libc` dependency for the Unix implementation

## Testing
- `cargo fmt`
- `cargo check` *(fails: tauri build script cannot resolve config in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c965d907f4832e91033369fc9774a8