### PR TITLE
Fix Tauri build manifest and env parsing

### DIFF
--- a/Launcher/src-tauri/src/main.rs
+++ b/Launcher/src-tauri/src/main.rs
@@ -21,8 +21,6 @@ use tokio::{
     time::sleep,
 };
 
-#[cfg(unix)]
-use tokio::process::unix::CommandExt;
 
 #[cfg(not(windows))]
 use tokio::time::timeout;
@@ -790,14 +788,6 @@ fn silly_env_port(silly_dir: &Path) -> Result<Option<u16>, String> {
     for entry in iter {
         let (key, value) =
             entry.map_err(|e| format!("Failed to parse {}: {e}", env_path.display()))?;
-        let key = match key.into_string() {
-            Ok(key) => key,
-            Err(_) => continue,
-        };
-        let value = match value.into_string() {
-            Ok(value) => value,
-            Err(_) => continue,
-        };
 
         match key.as_str() {
             "PORT" => {

--- a/Launcher/src-tauri/tauri.conf.json
+++ b/Launcher/src-tauri/tauri.conf.json
@@ -26,7 +26,12 @@
             "*"
           ],
           "permissions": [
-            "core:default"
+            "core:default",
+            "core:event:default",
+            "core:window:default",
+            "core:path:default",
+            "core:webview:default",
+            "core:app:default"
           ]
         }
       ]

--- a/Launcher/src-tauri/tauri.conf.json
+++ b/Launcher/src-tauri/tauri.conf.json
@@ -26,11 +26,7 @@
             "*"
           ],
           "permissions": [
-            "core:default",
-            "path:default",
-            "process:default",
-            "shell:default",
-            "fs:readFile"
+            "core:default"
           ]
         }
       ]


### PR DESCRIPTION
## Summary
- align the Tauri capability permissions with the available core manifest entries to unblock context generation
- simplify `.env` port parsing by working directly with the string keys and values returned by `dotenvy`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca84e27754832e9c2c4b6fd7fd8706